### PR TITLE
find_value: Add 'throw_if_not_present'

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -14,6 +14,8 @@
 #include <map>
 #include <cassert>
 
+#include <stdexcept>
+
 #include <sstream>        // .get_int64()
 #include <utility>        // std::pair
 
@@ -180,7 +182,7 @@ public:
     bool push_back(std::pair<std::string,UniValue> pear) {
         return pushKV(pear.first, pear.second);
     }
-    friend const UniValue& find_value( const UniValue& obj, const std::string& name);
+    friend const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present);
 };
 
 //
@@ -302,6 +304,11 @@ static inline bool json_isspace(int ch)
 
 extern const UniValue NullUniValue;
 
-const UniValue& find_value( const UniValue& obj, const std::string& name);
+const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present = false);
+
+class KeyNotPresentError: public std::runtime_error {
+    public:
+        KeyNotPresentError(): std::runtime_error("KeyNotPresentError") {}
+};
 
 #endif // __UNIVALUE_H__

--- a/include/univalue.h
+++ b/include/univalue.h
@@ -308,7 +308,7 @@ const UniValue& find_value(const UniValue& obj, const std::string& name, const b
 
 class KeyNotPresentError: public std::runtime_error {
     public:
-        KeyNotPresentError(): std::runtime_error("KeyNotPresentError") {}
+        explicit KeyNotPresentError(): std::runtime_error("KeyNotPresentError") {}
 };
 
 #endif // __UNIVALUE_H__

--- a/include/univalue.h
+++ b/include/univalue.h
@@ -22,6 +22,7 @@
 class UniValue {
 public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
+    enum keystatus { KEY_NOT_PRESENT, KEY_PRESENT };
 
     UniValue() { typ = VNULL; }
     UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
@@ -182,7 +183,7 @@ public:
     bool push_back(std::pair<std::string,UniValue> pear) {
         return pushKV(pear.first, pear.second);
     }
-    friend const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present);
+    friend const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status);
 };
 
 //
@@ -304,11 +305,6 @@ static inline bool json_isspace(int ch)
 
 extern const UniValue NullUniValue;
 
-const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present = false);
-
-class KeyNotPresentError: public std::runtime_error {
-    public:
-        explicit KeyNotPresentError(): std::runtime_error("KeyNotPresentError") {}
-};
+const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status=NULL);
 
 #endif // __UNIVALUE_H__

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -233,12 +233,16 @@ const char *uvTypeName(UniValue::VType t)
     return NULL;
 }
 
-const UniValue& find_value(const UniValue& obj, const std::string& name)
+const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present)
 {
-    for (unsigned int i = 0; i < obj.keys.size(); i++)
+    for (unsigned int i = 0; i < obj.keys.size(); i++) {
         if (obj.keys[i] == name)
             return obj.values.at(i);
+    }
+
+    if (throw_if_not_present) {
+        throw KeyNotPresentError();
+    }
 
     return NullUniValue;
 }
-

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -233,16 +233,15 @@ const char *uvTypeName(UniValue::VType t)
     return NULL;
 }
 
-const UniValue& find_value(const UniValue& obj, const std::string& name, const bool throw_if_not_present)
+const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status)
 {
     for (unsigned int i = 0; i < obj.keys.size(); i++) {
-        if (obj.keys[i] == name)
+        if (obj.keys[i] == name) {
+            if (status) { *status = UniValue::KEY_PRESENT; }
             return obj.values.at(i);
+        }
     }
 
-    if (throw_if_not_present) {
-        throw KeyNotPresentError();
-    }
-
+    if (status) { *status = UniValue::KEY_NOT_PRESENT; }
     return NullUniValue;
 }


### PR DESCRIPTION
Required in order to be able to distinguish between keys which do not exist
    and those which exist but point to null values.

If anyone has a better recommendation for which specific exception to throw here, or perhaps even a better way to do it, I'm all ears.