### PR TITLE
Split sources for easier buildsystem integration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I build-aux/m4
-.PHONY: gen
+.PHONY: gen FORCE
 .INTERMEDIATE: $(GENBIN)
 
 include_HEADERS = include/univalue.h
@@ -30,8 +30,8 @@ $(GENBIN): $(GEN_SRCS)
 	@echo Building $@
 	$(AM_V_at)c++ -I$(top_srcdir)/include -o $@ $<
 
-gen: lib/univalue_escapes.h $(GENBIN)
-	@echo Updating $<
+gen: $(GENBIN) FORCE
+	@echo Updating lib/univalue_escapes.h
 	$(AM_V_at)$(GENBIN) > lib/univalue_escapes.h
 
 noinst_PROGRAMS = $(TESTS) test/test_json

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,20 +1,17 @@
+include sources.mk
 ACLOCAL_AMFLAGS = -I build-aux/m4
 .PHONY: gen FORCE
 .INTERMEDIATE: $(GENBIN)
 
-include_HEADERS = include/univalue.h
-noinst_HEADERS = lib/univalue_escapes.h lib/univalue_utffilter.h
+include_HEADERS = $(UNIVALUE_DIST_HEADERS_INT)
+noinst_HEADERS = $(UNIVALUE_LIB_HEADERS_INT)
 
 lib_LTLIBRARIES = libunivalue.la
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = pc/libunivalue.pc
 
-libunivalue_la_SOURCES = \
-	lib/univalue.cpp \
-	lib/univalue_get.cpp \
-	lib/univalue_read.cpp \
-	lib/univalue_write.cpp
+libunivalue_la_SOURCES = $(UNIVALUE_LIB_SOURCES_INT)
 
 libunivalue_la_LDFLAGS = \
 	-version-info $(LIBUNIVALUE_CURRENT):$(LIBUNIVALUE_REVISION):$(LIBUNIVALUE_AGE) \
@@ -36,83 +33,26 @@ gen: $(GENBIN) FORCE
 
 noinst_PROGRAMS = $(TESTS) test/test_json
 
-TEST_DATA_DIR=test
-
-test_unitester_SOURCES = test/unitester.cpp
+test_unitester_SOURCES = $(UNIVALUE_TEST_UNITESTER_INT)
 test_unitester_LDADD = libunivalue.la
-test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(TEST_DATA_DIR)\"
+test_unitester_CXXFLAGS = -I$(top_srcdir)/include -DJSON_TEST_SRC=\"$(srcdir)/$(UNIVALUE_TEST_DATA_DIR_INT)\"
 test_unitester_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
-test_test_json_SOURCES = test/test_json.cpp
+test_test_json_SOURCES = $(UNIVALUE_TEST_JSON_INT)
 test_test_json_LDADD = libunivalue.la
 test_test_json_CXXFLAGS = -I$(top_srcdir)/include
 test_test_json_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
-test_no_nul_SOURCES = test/no_nul.cpp
+test_no_nul_SOURCES = $(UNIVALUE_TEST_NO_NUL_INT)
 test_no_nul_LDADD = libunivalue.la
 test_no_nul_CXXFLAGS = -I$(top_srcdir)/include
 test_no_nul_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
-test_object_SOURCES = test/object.cpp
+test_object_SOURCES = $(UNIVALUE_TEST_OBJECT_INT)
 test_object_LDADD = libunivalue.la
 test_object_CXXFLAGS = -I$(top_srcdir)/include
 test_object_LDFLAGS = -static $(LIBTOOL_APP_LDFLAGS)
 
-TEST_FILES = \
-	$(TEST_DATA_DIR)/fail10.json \
-	$(TEST_DATA_DIR)/fail11.json \
-	$(TEST_DATA_DIR)/fail12.json \
-	$(TEST_DATA_DIR)/fail13.json \
-	$(TEST_DATA_DIR)/fail14.json \
-	$(TEST_DATA_DIR)/fail15.json \
-	$(TEST_DATA_DIR)/fail16.json \
-	$(TEST_DATA_DIR)/fail17.json \
-	$(TEST_DATA_DIR)/fail18.json \
-	$(TEST_DATA_DIR)/fail19.json \
-	$(TEST_DATA_DIR)/fail1.json \
-	$(TEST_DATA_DIR)/fail20.json \
-	$(TEST_DATA_DIR)/fail21.json \
-	$(TEST_DATA_DIR)/fail22.json \
-	$(TEST_DATA_DIR)/fail23.json \
-	$(TEST_DATA_DIR)/fail24.json \
-	$(TEST_DATA_DIR)/fail25.json \
-	$(TEST_DATA_DIR)/fail26.json \
-	$(TEST_DATA_DIR)/fail27.json \
-	$(TEST_DATA_DIR)/fail28.json \
-	$(TEST_DATA_DIR)/fail29.json \
-	$(TEST_DATA_DIR)/fail2.json \
-	$(TEST_DATA_DIR)/fail30.json \
-	$(TEST_DATA_DIR)/fail31.json \
-	$(TEST_DATA_DIR)/fail32.json \
-	$(TEST_DATA_DIR)/fail33.json \
-	$(TEST_DATA_DIR)/fail34.json \
-	$(TEST_DATA_DIR)/fail35.json \
-	$(TEST_DATA_DIR)/fail36.json \
-	$(TEST_DATA_DIR)/fail37.json \
-	$(TEST_DATA_DIR)/fail38.json \
-	$(TEST_DATA_DIR)/fail39.json \
-	$(TEST_DATA_DIR)/fail40.json \
-	$(TEST_DATA_DIR)/fail41.json \
-	$(TEST_DATA_DIR)/fail42.json \
-	$(TEST_DATA_DIR)/fail44.json \
-	$(TEST_DATA_DIR)/fail45.json \
-	$(TEST_DATA_DIR)/fail3.json \
-	$(TEST_DATA_DIR)/fail4.json \
-	$(TEST_DATA_DIR)/fail5.json \
-	$(TEST_DATA_DIR)/fail6.json \
-	$(TEST_DATA_DIR)/fail7.json \
-	$(TEST_DATA_DIR)/fail8.json \
-	$(TEST_DATA_DIR)/fail9.json \
-	$(TEST_DATA_DIR)/pass1.json \
-	$(TEST_DATA_DIR)/pass2.json \
-	$(TEST_DATA_DIR)/pass3.json \
-	$(TEST_DATA_DIR)/pass4.json \
-	$(TEST_DATA_DIR)/round1.json \
-	$(TEST_DATA_DIR)/round2.json \
-	$(TEST_DATA_DIR)/round3.json \
-	$(TEST_DATA_DIR)/round4.json \
-	$(TEST_DATA_DIR)/round5.json \
-	$(TEST_DATA_DIR)/round6.json \
-	$(TEST_DATA_DIR)/round7.json
+TEST_FILES = $(UNIVALUE_TEST_FILES_INT)
 
-EXTRA_DIST=$(TEST_FILES) $(GEN_SRCS)
+EXTRA_DIST=$(UNIVALUE_TEST_FILES_INT) $(GEN_SRCS)

--- a/sources.mk
+++ b/sources.mk
@@ -1,0 +1,95 @@
+# - All variables are namespaced with UNIVALUE_ to avoid colliding with
+#     downstream makefiles.
+# - All Variables ending in _HEADERS or _SOURCES confuse automake, so the
+#     _INT postfix is applied.
+# - Convenience variables, for example a UNIVALUE_TEST_DIR should not be used
+#     as they interfere with automatic dependency generation
+# - The %reldir% is the relative path from the Makefile.am. This allows
+#   downstreams to use these variables without having to manually account for
+#   the path change.
+
+UNIVALUE_INCLUDE_DIR_INT = %reldir%/include
+
+UNIVALUE_DIST_HEADERS_INT =
+UNIVALUE_DIST_HEADERS_INT += %reldir%/include/univalue.h
+
+UNIVALUE_LIB_HEADERS_INT =
+UNIVALUE_LIB_HEADERS_INT += %reldir%/lib/univalue_utffilter.h
+UNIVALUE_LIB_HEADERS_INT += %reldir%/lib/univalue_escapes.h
+
+UNIVALUE_LIB_SOURCES_INT =
+UNIVALUE_LIB_SOURCES_INT += %reldir%/lib/univalue.cpp
+UNIVALUE_LIB_SOURCES_INT += %reldir%/lib/univalue_get.cpp
+UNIVALUE_LIB_SOURCES_INT += %reldir%/lib/univalue_read.cpp
+UNIVALUE_LIB_SOURCES_INT += %reldir%/lib/univalue_write.cpp
+
+UNIVALUE_TEST_DATA_DIR_INT = %reldir%/test
+
+UNIVALUE_TEST_UNITESTER_INT =
+UNIVALUE_TEST_UNITESTER_INT += %reldir%/test/unitester.cpp
+
+UNIVALUE_TEST_JSON_INT =
+UNIVALUE_TEST_JSON_INT += %reldir%/test/test_json.cpp
+
+UNIVALUE_TEST_NO_NUL_INT =
+UNIVALUE_TEST_NO_NUL_INT += %reldir%/test/no_nul.cpp
+
+UNIVALUE_TEST_OBJECT_INT =
+UNIVALUE_TEST_OBJECT_INT += %reldir%/test/object.cpp
+
+UNIVALUE_TEST_FILES_INT =
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail1.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail2.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail3.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail4.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail5.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail6.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail7.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail8.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail9.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail10.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail11.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail12.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail13.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail14.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail15.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail16.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail17.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail18.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail19.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail20.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail21.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail22.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail23.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail24.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail25.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail26.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail27.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail28.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail29.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail30.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail31.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail32.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail33.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail34.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail35.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail36.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail37.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail38.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail39.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail40.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail41.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail42.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail44.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/fail45.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/pass1.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/pass2.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/pass3.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/pass4.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round1.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round2.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round3.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round4.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round5.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round6.json
+UNIVALUE_TEST_FILES_INT += %reldir%/test/round7.json


### PR DESCRIPTION
This addresses issues like the one in https://github.com/bitcoin/bitcoin/pull/12467, where some of our compiler flags end up being dropped during the subconfigure of Univalue. Specifically, we're still using the compiler-default c++ version rather than forcing c++17.

We can drop the need subconfigure completely in favor of a tighter build integration, where the sources are listed separately from the build recipes, so that they may be included directly by upstream projects. This is similar to the way leveldb build integration works in Core.

A similar split was recently added for minisketch: https://github.com/sipa/minisketch/pull/8

Upstream benefits of this approach include:
- Better caching (for ex. ccache and autoconf)
- No need for a slow subconfigure
- No more missing compile flags
- Compile only the objects needed

There are no benefits to Univalue itself that I can think of. These changes should be a no-op here, and to downstreams as well until they take advantage of the new sources.mk. Once merged, [This Core branch](https://github.com/theuni/bitcoin/commits/univalue-split) is ready-ish for PR, and takes advantage of the features added here.


libsecp256k1 will get the same treatment once this is done.