### PR TITLE
build: Include autogen.sh in EXTRA_DIST

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -113,4 +113,4 @@ TEST_FILES = \
 	$(TEST_DATA_DIR)/round6.json \
 	$(TEST_DATA_DIR)/round7.json
 
-EXTRA_DIST=$(TEST_FILES) $(GEN_SRCS)
+EXTRA_DIST = autogen.sh $(TEST_FILES) $(GEN_SRCS)


### PR DESCRIPTION
Adds `autogen.sh` to the distribution; corresponds to:
https://github.com/bitcoin-core/secp256k1/blob/0d9540b13ffcd7cd44cc361b8744b93d88aa76ba/Makefile.am#L175

Noticed when working with `make dist` in Bitcoin.
Got an error when entering src/univalue, something like:
```
make[6]: Leaving directory '/Users/Jon/bitcoin/src/secp256k1'
make[5]: Leaving directory '/Users/Jon/bitcoin/src/secp256k1'
 (cd univalue && make  top_distdir=../../bitcoin-0.19.99 distdir=../../bitcoin-0.19.99/src/univalue \
     am__remove_distdir=: am__skip_length_check=: am__skip_mode_fix=: distdir)
make[5]: Entering directory '/Users/Jon/bitcoin/src/univalue'
>>> No rule to make target `distdir`.
```
This fixed itself when autogen.sh was added. Can't replicate it now, unfortunately.