### PR TITLE
Iterate backwards in findKey to mimic behavior of scripting languages:

### DIFF
--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -166,7 +166,7 @@ void UniValue::getObjMap(std::map<std::string,UniValue>& kv) const
 
 bool UniValue::findKey(const std::string& key, size_t& retIdx) const
 {
-    for (size_t i = 0; i < keys.size(); i++) {
+    for (ssize_t i = keys.size() - 1; i >= 0; i--) {
         if (keys[i] == key) {
             retIdx = i;
             return true;


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/20949

``` cpp
UniValue json;
json.read("{\"a\": \"first\", \"a\": \"second\"}");
```

Univalue before this commit returns `"first"` for `json["a"]`.

Univalue after this commit returns `"second"` for `json["a"]`.

Python:
``` python
>>> json.loads('{"a": "first", "a": "second"}')
{'a': 'second'}
```

Javascript:
``` javascript
>>> JSON.parse('{"a": "first", "a": "second"}')
{a: "second"}
```