### PR TITLE
various performance improvements

### DIFF
--- a/include/univalue.h
+++ b/include/univalue.h
@@ -59,21 +59,11 @@ public:
     UniValue(const std::string& val_) : typ(VSTR), val(val_) {}
     UniValue(std::string&& val_) : typ(VSTR), val(std::move(val_)) {}
     UniValue(const char *val_) : typ(VSTR), val(val_) {}
-    UniValue(uint64_t val_) {
-        setInt(val_);
-    }
-    UniValue(int64_t val_) {
-        setInt(val_);
-    }
-    UniValue(bool val_) {
-        setBool(val_);
-    }
-    UniValue(int val_) {
-        setInt(val_);
-    }
-    UniValue(double val_) {
-        setFloat(val_);
-    }
+    UniValue(uint64_t val_);
+    UniValue(int64_t val_);
+    UniValue(bool val_);
+    UniValue(int val_);
+    UniValue(double val_);
 
     void clear();
 

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -5,15 +5,42 @@
 
 #include <univalue.h>
 
+#include <algorithm>
 #include <iomanip>
 #include <map>
 #include <memory>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 const UniValue NullUniValue;
+
+namespace {
+
+/**
+ * Performs locale-independend to string conversion of integral numbers.
+ *
+ * This is much faster than using a temporary stringstream.
+ */
+template<typename T>
+void appendNumToString(T n, std::string& str)
+{
+    auto unsigned_n = static_cast<typename std::make_unsigned<T>::type>(n);
+    if (n < 0) {
+        str.push_back('-');
+        unsigned_n = 0 - unsigned_n;
+    }
+    auto old_size = str.size();
+    do {
+        str.push_back(static_cast<char>('0' + (unsigned_n % 10)));
+        unsigned_n /= 10;
+    } while (unsigned_n);
+    std::reverse(str.begin() + old_size, str.end());
+}
+
+}
 
 void UniValue::clear()
 {
@@ -59,20 +86,18 @@ bool UniValue::setNumStr(const std::string& val_)
 
 bool UniValue::setInt(uint64_t val_)
 {
-    std::ostringstream oss;
-
-    oss << val_;
-
-    return setNumStr(oss.str());
+    clear();
+    typ = VNUM;
+    appendNumToString(val_, val);
+    return true;
 }
 
 bool UniValue::setInt(int64_t val_)
 {
-    std::ostringstream oss;
-
-    oss << val_;
-
-    return setNumStr(oss.str());
+    clear();
+    typ = VNUM;
+    appendNumToString(val_, val);
+    return true;
 }
 
 bool UniValue::setFloat(double val_)

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -42,6 +42,32 @@ void appendNumToString(T n, std::string& str)
 
 }
 
+UniValue::UniValue(uint64_t val_) : typ(VNUM)
+{
+    appendNumToString(val_, val);
+}
+
+UniValue::UniValue(int64_t val_) : typ(VNUM)
+{
+    appendNumToString(val_, val);
+}
+
+UniValue::UniValue(bool val_) : typ(VBOOL)
+{
+    if (val_)
+        val = "1";
+}
+
+UniValue::UniValue(int val_) : typ(VNUM)
+{
+    appendNumToString(val_, val);
+}
+
+UniValue::UniValue(double val_) : typ(VNUM)
+{
+    setFloat(val_);
+}
+
 void UniValue::clear()
 {
     typ = VNULL;

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -328,7 +328,7 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(utyp);
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
 
                 UniValue *newTop = &(top->values.back());
                 stack.push_back(newTop);
@@ -403,12 +403,12 @@ bool UniValue::read(const char *raw, size_t size)
             }
 
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -417,12 +417,12 @@ bool UniValue::read(const char *raw, size_t size)
         case JTOK_NUMBER: {
             UniValue tmpVal(VNUM, tokenVal);
             if (!stack.size()) {
-                *this = tmpVal;
+                *this = std::move(tmpVal);
                 break;
             }
 
             UniValue *top = stack.back();
-            top->values.push_back(tmpVal);
+            top->values.push_back(std::move(tmpVal));
 
             setExpect(NOT_VALUE);
             break;
@@ -437,11 +437,11 @@ bool UniValue::read(const char *raw, size_t size)
             } else {
                 UniValue tmpVal(VSTR, tokenVal);
                 if (!stack.size()) {
-                    *this = tmpVal;
+                    *this = std::move(tmpVal);
                     break;
                 }
                 UniValue *top = stack.back();
-                top->values.push_back(tmpVal);
+                top->values.push_back(std::move(tmpVal));
             }
 
             setExpect(NOT_VALUE);

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(univalue_array)
     UniValue arr(UniValue::VARR);
 
     UniValue v((int64_t)1023LL);
-    BOOST_CHECK(arr.push_back(v));
+    BOOST_CHECK(arr.push_back(v.copy()));
 
     std::string vStr("zippy");
     BOOST_CHECK(arr.push_back(vStr));
@@ -202,12 +202,12 @@ BOOST_AUTO_TEST_CASE(univalue_array)
 
     std::vector<UniValue> vec;
     v.setStr("boing");
-    vec.push_back(v);
+    vec.push_back(v.copy());
 
     v.setStr("going");
-    vec.push_back(v);
+    vec.push_back(v.copy());
 
-    BOOST_CHECK(arr.push_backV(vec));
+    BOOST_CHECK(arr.push_backV(std::move(vec)));
 
     BOOST_CHECK(arr.push_back((uint64_t) 400ULL));
     BOOST_CHECK(arr.push_back((int64_t) -400LL));
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
 
     strKey = "age";
     v.setInt(100);
-    BOOST_CHECK(obj.pushKV(strKey, v));
+    BOOST_CHECK(obj.pushKV(strKey, std::move(v)));
 
     strKey = "first";
     strVal = "John";
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK(obj2.pushKV("cat1", 9000));
     BOOST_CHECK(obj2.pushKV("cat2", 12345));
 
-    BOOST_CHECK(obj.pushKVs(obj2));
+    BOOST_CHECK(obj.pushKVs(std::move(obj2)));
 
     BOOST_CHECK_EQUAL(obj.empty(), false);
     BOOST_CHECK_EQUAL(obj.size(), 11);
@@ -344,12 +344,12 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK_EQUAL(obj.setObject(), true);
     UniValue uv;
     uv.setInt(42);
-    obj.__pushKV("age", uv);
+    obj.__pushKV("age", uv.copy());
     BOOST_CHECK_EQUAL(obj.size(), 1);
     BOOST_CHECK_EQUAL(obj["age"].getValStr(), "42");
 
     uv.setInt(43);
-    obj.pushKV("age", uv);
+    obj.pushKV("age", std::move(uv));
     BOOST_CHECK_EQUAL(obj.size(), 1);
     BOOST_CHECK_EQUAL(obj["age"].getValStr(), "43");
 
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(univalue_readwrite)
 
     BOOST_CHECK_EQUAL(v[0].getValStr(), "1.10000000");
 
-    UniValue obj = v[1];
+    const UniValue& obj = v[1];
     BOOST_CHECK(obj.isObject());
     BOOST_CHECK_EQUAL(obj.size(), 3);
 

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -407,6 +408,30 @@ BOOST_AUTO_TEST_CASE(univalue_readwrite)
     BOOST_CHECK(!v.read("{} 42"));
 }
 
+BOOST_AUTO_TEST_CASE(univalue_numbers)
+{
+    UniValue v;
+    BOOST_CHECK(v.setInt(std::numeric_limits<int64_t>::max()));
+    BOOST_CHECK(v.isNum());
+    BOOST_CHECK_EQUAL(v.getValStr(), "9223372036854775807");
+
+    BOOST_CHECK(v.setInt(std::numeric_limits<int64_t>::lowest()));
+    BOOST_CHECK(v.isNum());
+    BOOST_CHECK_EQUAL(v.getValStr(), "-9223372036854775808");
+
+    BOOST_CHECK(v.setInt(int64_t(0)));
+    BOOST_CHECK(v.isNum());
+    BOOST_CHECK_EQUAL(v.getValStr(), "0");
+
+    BOOST_CHECK(v.setInt(std::numeric_limits<uint64_t>::max()));
+    BOOST_CHECK(v.isNum());
+    BOOST_CHECK_EQUAL(v.getValStr(), "18446744073709551615");
+
+    BOOST_CHECK(v.setInt(uint64_t(0)));
+    BOOST_CHECK(v.isNum());
+    BOOST_CHECK_EQUAL(v.getValStr(), "0");
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 int main (int argc, char *argv[])
@@ -417,6 +442,7 @@ int main (int argc, char *argv[])
     univalue_array();
     univalue_object();
     univalue_readwrite();
+    univalue_numbers();
     return 0;
 }
 


### PR DESCRIPTION
This PR contains has a few performance improvements for `UniValue`.  Most importantly, it adds move semantics, and a way to easily transition legacy code to make use of the new methods.

I've used `BlockToJsonVerbose` as my benchmark. With this PR alone the benchmark runs 1.26 times faster. When actually making use of the new move semantics in bitcoin's `core_write.cpp` and `blockchain.cpp`, this speeds up the benchmark by a factor of ~2.3 on my machine.

|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|       63,370,373.00 |               15.78 |    0.9% |      0.70 | `BlockToJsonVerbose` master
|       50,111,950.00 |               19.96 |    0.7% |      0.56 | `BlockToJsonVerbose` this PR
|       27,775,808.00 |               36.00 |    0.4% |      0.31 | `BlockToJsonVerbose` this PR + using move semantics in core_write.cpp and blockchain.cpp

I got no response whatsoever on move-semantic PR on https://github.com/jgarzik/univalue/pull/79 from about 8 months ago, so I'm opening this PR here and close the other one.