### PR TITLE
refactor: include-what-you-use

### DIFF
--- a/gen/gen.cpp
+++ b/gen/gen.cpp
@@ -8,9 +8,11 @@
 // $ ./gen > univalue_escapes.h
 //
 
-#include <stdio.h>
-#include <string.h>
-#include "univalue.h"
+#include <univalue.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
 
 static bool initEscapes;
 static std::string escapes[256];

--- a/include/univalue.h
+++ b/include/univalue.h
@@ -6,13 +6,11 @@
 #ifndef __UNIVALUE_H__
 #define __UNIVALUE_H__
 
-#include <stdint.h>
-#include <string.h>
-
+#include <cstdint>
+#include <cstring>
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
-#include <cassert>
 
 class UniValue {
 public:

--- a/lib/univalue.cpp
+++ b/lib/univalue.cpp
@@ -3,12 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
-#include <iomanip>
-#include <sstream>
-#include <stdlib.h>
+#include <univalue.h>
 
-#include "univalue.h"
+#include <iomanip>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 const UniValue NullUniValue;
 

--- a/lib/univalue_get.cpp
+++ b/lib/univalue_get.cpp
@@ -3,17 +3,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdexcept>
-#include <vector>
-#include <limits>
-#include <string>
-#include <sstream>
+#include <univalue.h>
 
-#include "univalue.h"
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <locale>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace
 {

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -2,11 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <string.h>
-#include <vector>
-#include <stdio.h>
-#include "univalue.h"
+#include <univalue.h>
 #include "univalue_utffilter.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
 
 /*
  * According to stackexchange, the original json test suite wanted

--- a/lib/univalue_read.cpp
+++ b/lib/univalue_read.cpp
@@ -17,7 +17,7 @@
  * so we will follow PHP's lead, which should be more than sufficient
  * (further stackexchange comments indicate depth > 32 rarely occurs).
  */
-static const size_t MAX_JSON_DEPTH = 512;
+static constexpr size_t MAX_JSON_DEPTH = 512;
 
 static bool json_isdigit(int ch)
 {

--- a/lib/univalue_write.cpp
+++ b/lib/univalue_write.cpp
@@ -2,10 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <iomanip>
-#include <stdio.h>
-#include "univalue.h"
+#include <univalue.h>
 #include "univalue_escapes.h"
+
+#include <memory>
+#include <string>
+#include <vector>
 
 static std::string json_escape(const std::string& inS)
 {

--- a/test/no_nul.cpp
+++ b/test/no_nul.cpp
@@ -1,4 +1,4 @@
-#include "univalue.h"
+#include <univalue.h>
 
 int main (int argc, char *argv[])
 {

--- a/test/object.cpp
+++ b/test/object.cpp
@@ -3,13 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
-#include <vector>
-#include <string>
-#include <map>
-#include <cassert>
-#include <stdexcept>
 #include <univalue.h>
+
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 #define BOOST_FIXTURE_TEST_SUITE(a, b)
 #define BOOST_AUTO_TEST_CASE(funcName) void funcName()

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -4,9 +4,11 @@
 // It reads JSON input from stdin and exits with code 0 if it can be parsed
 // successfully. It also pretty prints the parsed JSON value to stdout.
 
+#include <univalue.h>
+
 #include <iostream>
+#include <iterator>
 #include <string>
-#include "univalue.h"
 
 using namespace std;
 

--- a/test/unitester.cpp
+++ b/test/unitester.cpp
@@ -2,12 +2,11 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or https://opensource.org/licenses/mit-license.php.
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
+#include <univalue.h>
+
 #include <cassert>
+#include <cstdio>
 #include <string>
-#include "univalue.h"
 
 #ifndef JSON_TEST_SRC
 #error JSON_TEST_SRC must point to test source directory


### PR DESCRIPTION
With there changes there is a single suggested include, which is incorrect, and can be dealt with in our mapping file:
```bash
lib/univalue.cpp should add these lines:
#include <ext/alloc_traits.h>  // for __alloc_traits<>::value_type
```